### PR TITLE
Hide element_mypaint topics from pkgdown reference

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -58,6 +58,10 @@ reference:
     contents:
       - knitr_mypaint_hook
 
+  - title: internal
+    contents:
+      - starts_with("element_mypaint_")
+
 navbar:
   structure:
     left: [reference, articles]


### PR DESCRIPTION
### Motivation
- Prevent `element_mypaint_*` topics from appearing in the public pkgdown reference index while keeping them defined for pkgdown's inclusion logic.

### Description
- Added an `internal` reference section to `_pkgdown.yml` with `contents: - starts_with("element_mypaint_")` to group and hide those topics from the visible reference.

### Testing
- Verified the updated `_pkgdown.yml` parses in R with `yaml::read_yaml('_pkgdown.yml')` and includes the new `internal` section; attempting `pkgdown::build_reference_index('.')` in this environment failed with `Run pkgdown::init_site() first.` which is unrelated to the YAML change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9026712a4833093ee83f635def5b9)