### PR TITLE
Wrap `mypaint_wrap()` style around ggplot legend keys

### DIFF
--- a/R/ggplot.R
+++ b/R/ggplot.R
@@ -365,6 +365,14 @@ mypaint_wrap.LayerInstance <- function(object,
   object$draw_geom <- function(self, data, layout) {
     wrap_mypaintr_style_output(old_draw_geom(data, layout), style)
   }
+  old_draw_key <- object$geom$draw_key
+  object$geom <- ggplot2::ggproto(
+    NULL,
+    object$geom,
+    draw_key = function(data, params, size) {
+      wrap_mypaintr_style_output(old_draw_key(data, params, size), style)
+    }
+  )
   object
 }
 


### PR DESCRIPTION
### Motivation
- `mypaint_wrap()` currently wraps a ggplot layer's panel drawing (`draw_geom`) but does not apply the same mypaintr style to the layer's legend key, producing mismatched appearance between the plot and its legend.

### Description
- Update `mypaint_wrap.LayerInstance()` in `R/ggplot.R` to also wrap the layer geom's `draw_key` output with `wrap_mypaintr_style_output()` so legend keys receive the same mypaintr styling as the geom.
- Implement the key wrapping by cloning the layer's `geom` with `ggplot2::ggproto(NULL, object$geom, draw_key = ...)` and overriding `draw_key` to call `wrap_mypaintr_style_output()` on the original key grob.
- Preserve the existing `draw_geom` wrapper so panel rendering behavior is unchanged.

### Testing
- Ran `Rscript -e "invisible(parse(file='R/ggplot.R'))"` to ensure the modified file parses successfully and this check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb39243b88330a31bc1570890f80b)