### PR TITLE
Allow `set_hand()` to persist defaults without an active mypaint device

### DIFF
--- a/R/device-style.R
+++ b/R/device-style.R
@@ -5,6 +5,8 @@
 
 mypaintr_env <- new.env(parent = emptyenv())
 mypaintr_env$style_stack <- list()
+mypaintr_env$default_stroke_hand <- NULL
+mypaintr_env$default_fill_hand <- NULL
 
 is_mypaintr_device <- function() {
   identical(names(grDevices::dev.cur()), "mypaintr")
@@ -170,6 +172,12 @@ mypaint_device <- function(filename = NULL,
   }
   if (fill_hand_missing) {
     fill_hand <- hand
+  }
+  if (hand_missing && stroke_hand_missing) {
+    stroke_hand <- mypaintr_env$default_stroke_hand
+  }
+  if (hand_missing && fill_hand_missing) {
+    fill_hand <- mypaintr_env$default_fill_hand
   }
 
   stroke_spec <- if (brush_missing) {

--- a/R/hands.R
+++ b/R/hands.R
@@ -159,16 +159,23 @@ human_hand <- function(seed = NULL,
 #'   fully plain, solid rendering.
 #' @param type Which rendering channel to update: `"both"`, `"stroke"`, or
 #'   `"fill"`.
-#' @return `NULL`, invisibly. If the active graphics device is not
-#'   [mypaint_device()], this emits a warning and has no effect.
+#' @return `NULL`, invisibly. Updates the default hand settings used when
+#'   [mypaint_device()] opens, and also updates the active device when it is a
+#'   [mypaint_device()].
 #' @export
 set_hand <- function(hand = NULL, type = c("both", "stroke", "fill")) {
   type <- match.arg(type)
   stroke_hand <- if (type %in% c("both", "stroke")) normalize_hand_spec(hand) else NULL
   fill_hand <- if (type %in% c("both", "fill")) normalize_hand_spec(hand) else NULL
 
+  if (type %in% c("both", "stroke")) {
+    mypaintr_env$default_stroke_hand <- stroke_hand
+  }
+  if (type %in% c("both", "fill")) {
+    mypaintr_env$default_fill_hand <- fill_hand
+  }
+
   if (!is_mypaintr_device()) {
-    warn_no_mypaintr_device("set_hand")
     return(invisible(NULL))
   }
 

--- a/man/set_hand.Rd
+++ b/man/set_hand.Rd
@@ -17,8 +17,9 @@ fully plain, solid rendering.}
 \code{"fill"}.}
 }
 \value{
-\code{NULL}, invisibly. If the active graphics device is not
-\code{\link[=mypaint_device]{mypaint_device()}}, this emits a warning and has no effect.
+\code{NULL}, invisibly. Updates the default hand settings used when
+\code{\link[=mypaint_device]{mypaint_device()}} opens, and also updates the active device when it is a
+\code{\link[=mypaint_device]{mypaint_device()}}.
 }
 \description{
 Set the active hand


### PR DESCRIPTION
### Motivation
- `set_hand()` previously only took effect when a `mypaint_device()` was open, which prevented users from configuring default hand settings ahead of opening a device.
- The change makes it possible to configure hand settings independently of device state so those defaults are applied when a device is later opened.

### Description
- Add package-level default slots `mypaintr_env$default_stroke_hand` and `mypaintr_env$default_fill_hand` to store persistent hand settings. (`R/device-style.R`)
- Update `set_hand()` to write into those defaults always and to continue applying to the active device when one is open, removing the no-op warning when no device is active. (`R/hands.R`, `man/set_hand.Rd`)
- Have `mypaint_device()` consume the stored defaults when `hand`, `stroke_hand`, or `fill_hand` are omitted so prior `set_hand()` calls take effect on device open. (`R/device-style.R`)

### Testing
- Ran `Rscript -e "parse('R/device-style.R'); parse('R/hands.R'); cat('OK\n')"` which succeeded. 
- Ran an interactive verification by sourcing the updated files and exercising `set_hand()` to assert `mypaintr_env$default_stroke_hand` and `mypaintr_env$default_fill_hand` are updated as expected, which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd7bf06848330a76e12c5ecaae935)