### PR TITLE
Inline single-use internals; remove unused helper; update demo example

### DIFF
--- a/R/brushes.R
+++ b/R/brushes.R
@@ -247,10 +247,6 @@ normalize_brush_spec <- function(brush) {
   )
 }
 
-is_probably_pure_smudge_brush <- function(spec) {
-  FALSE
-}
-
 warn_if_pure_smudge_brush <- function(spec, type = c("stroke", "fill")) {
   type <- match.arg(type)
   invisible(NULL)

--- a/R/draw-rough.R
+++ b/R/draw-rough.R
@@ -1,10 +1,4 @@
 
-rough_control_offsets <- function(t, amplitude) {
-  ctrl_x <- c(0, 0.33, 0.66, 1)
-  ctrl_y <- c(0, stats::rnorm(2, sd = amplitude), 0)
-  stats::approx(ctrl_x, ctrl_y, xout = t, rule = 2)$y
-}
-
 rough_segment_path <- function(x0, y0, x1, y1, hand_spec) {
   dx <- x1 - x0
   dy <- y1 - y0
@@ -36,7 +30,12 @@ rough_segment_path <- function(x0, y0, x1, y1, hand_spec) {
   base_x <- sx + (ex - sx) * t
   base_y <- sy + (ey - sy) * t
   bow <- bow_amp * sin(pi * t)
-  wobble <- rough_control_offsets(t, wobble_amp) * sin(pi * t)
+  wobble <- stats::approx(
+    c(0, 0.33, 0.66, 1),
+    c(0, stats::rnorm(2, sd = wobble_amp), 0),
+    xout = t,
+    rule = 2
+  )$y * sin(pi * t)
   offset <- bow + wobble
 
   list(
@@ -113,27 +112,6 @@ rough_segments <- function(x0, y0, x1, y1, hand = NULL) {
   })
 }
 
-rough_lines_data <- function(x, y = NULL, hand_spec) {
-  xy <- grDevices::xy.coords(x, y)
-  ok <- stats::complete.cases(xy$x, xy$y)
-  groups <- cumsum(!ok)
-  keep_groups <- unique(groups[ok])
-
-  out_x <- numeric()
-  out_y <- numeric()
-  out_id <- integer()
-  for (i in seq_along(keep_groups)) {
-    keep <- ok & groups == keep_groups[[i]]
-    if (sum(keep) >= 2L) {
-      out_x <- c(out_x, xy$x[keep])
-      out_y <- c(out_y, xy$y[keep])
-      out_id <- c(out_id, rep.int(i, sum(keep)))
-    }
-  }
-
-  list(x = out_x, y = out_y, id = out_id)
-}
-
 #' Compute or draw rough connected lines
 #'
 #' @param x,y Coordinates as for [graphics::lines()].
@@ -144,17 +122,25 @@ rough_lines_data <- function(x, y = NULL, hand_spec) {
 rough_lines <- function(x, y = NULL, hand = NULL) {
   hand_spec <- as_hand(hand)
   with_hand_seed(hand_spec$seed, {
-    rough_lines_data(x, y, hand_spec)
-  })
-}
+    xy <- grDevices::xy.coords(x, y)
+    ok <- stats::complete.cases(xy$x, xy$y)
+    groups <- cumsum(!ok)
+    keep_groups <- unique(groups[ok])
 
-arrow_unit_scale <- function() {
-  usr <- graphics::par("usr")
-  pin <- graphics::par("pin")
-  c(
-    x = abs(usr[2] - usr[1]) / pin[1],
-    y = abs(usr[4] - usr[3]) / pin[2]
-  )
+    out_x <- numeric()
+    out_y <- numeric()
+    out_id <- integer()
+    for (i in seq_along(keep_groups)) {
+      keep <- ok & groups == keep_groups[[i]]
+      if (sum(keep) >= 2L) {
+        out_x <- c(out_x, xy$x[keep])
+        out_y <- c(out_y, xy$y[keep])
+        out_id <- c(out_id, rep.int(i, sum(keep)))
+      }
+    }
+
+    list(x = out_x, y = out_y, id = out_id)
+  })
 }
 
 arrowhead_segments <- function(x0, y0, x1, y1, length = 0.25, angle = 30, code = 2) {
@@ -167,7 +153,12 @@ arrowhead_segments <- function(x0, y0, x1, y1, length = 0.25, angle = 30, code =
   code <- rep_len(as.integer(code), n)
   angle <- rep_len(angle, n)
 
-  scale <- arrow_unit_scale()
+  usr <- graphics::par("usr")
+  pin <- graphics::par("pin")
+  scale <- c(
+    x = abs(usr[2] - usr[1]) / pin[1],
+    y = abs(usr[4] - usr[3]) / pin[2]
+  )
   seg_x0 <- numeric()
   seg_y0 <- numeric()
   seg_x1 <- numeric()

--- a/R/knitr-hook.R
+++ b/R/knitr-hook.R
@@ -1,15 +1,4 @@
 
-require_knitr <- function() {
-  if (!requireNamespace("knitr", quietly = TRUE)) {
-    stop("knitr must be installed to use knitr_mypaint_hook()", call. = FALSE)
-  }
-}
-
-chunk_sets_dev_explicitly <- function(options) {
-  src <- options$params.src %||% ""
-  is.character(src) && length(src) == 1L && grepl("(^|,)\\s*dev\\s*=", src, perl = TRUE)
-}
-
 #' Create a knitr chunk hook for live mypaint rendering
 #'
 #' The returned hook opens [mypaint_device()] before chunk evaluation and
@@ -36,14 +25,19 @@ chunk_sets_dev_explicitly <- function(options) {
 #' }
 #' @export
 knitr_mypaint_hook <- function(...) {
-  require_knitr()
+  if (!requireNamespace("knitr", quietly = TRUE)) {
+    stop("knitr must be installed to use knitr_mypaint_hook()", call. = FALSE)
+  }
   device_defaults <- list(...)
 
   function(before, options, envir) {
     if (!isTRUE(options$mypaint)) {
       return()
     }
-    if (chunk_sets_dev_explicitly(options)) {
+    src <- options$params.src %||% ""
+    has_explicit_dev <- is.character(src) && length(src) == 1L &&
+      grepl("(^|,)\\s*dev\\s*=", src, perl = TRUE)
+    if (has_explicit_dev) {
       return()
     }
 

--- a/inst/examples/demo.R
+++ b/inst/examples/demo.R
@@ -4,8 +4,8 @@ mypaint_device(
   "demo-%d.png",
   width = 5,
   height = 4,
-  brush = "chalk",
-  fill_style = "brush"
+  brush = "deevad/chalk",
+  fill_brush = "deevad/chalk"
 )
 
 plot(1:10, col = "grey30", pch = 16, cex = 1.5)


### PR DESCRIPTION
### Motivation
- Reduce indirection by inlining internal helper functions that are only used once to simplify the code and remove dead helpers.
- Ensure the shipped example matches the current `mypaint_device()` API.

### Description
- Inlined `require_knitr()` and the explicit-`dev=` chunk detection into `knitr_mypaint_hook()` to remove two small one-use helpers in `R/knitr-hook.R`.
- Inlined wobble interpolation into `rough_segment_path()`, moved connected-line assembly into `rough_lines()`, and embedded arrow unit scaling into `arrowhead_segments()` to remove small private helpers in `R/draw-rough.R`.
- Removed the unexported unused function `is_probably_pure_smudge_brush()` from `R/brushes.R`.
- Updated `inst/examples/demo.R` to use the current device argument `fill_brush` instead of the invalid `fill_style`, and use an explicit installed brush path (`deevad/chalk`).

### Testing
- Ran `R CMD INSTALL .` which completed successfully after installing required system libraries (`libcairo2-dev`, `libjson-c-dev`) and R dependencies (`ggplot2`, `knitr`, `rmarkdown`).
- Exercised package examples via `tools::testInstalledPackage("mypaintr", outDir = "tmp-example-check")` and executed `inst/examples/demo.R`, both of which ran (the demo required the example change to `fill_brush`).
- Rendered vignettes with `rmarkdown::render()` where `classic-graphs.Rmd`, `hand-demo.Rmd`, and `introduction.Rmd` completed, while `brush-gallery.Rmd` exceeded a 180s render timeout in this environment.
- Noted initial `R CMD check` failures were due to missing system/R dependencies in the environment and were resolved by installing those dependencies; subsequent installs and runtime checks succeeded for the automated example tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef48e85bd48330aedb903fe7df68d7)