### PR TITLE
[codex] Use device hand for rough shapes

### DIFF
--- a/R/draw-rough.R
+++ b/R/draw-rough.R
@@ -505,10 +505,10 @@ draw_mypaintr_rough_shape <- function(primitive, shape_args, paths, hand_spec,
 
   state <- current_device_style()
   on.exit(apply_device_style_state(state), add = TRUE)
-  invisible(.Call(mypaintr_device_set_hand, hand_spec, hand_spec, TRUE, TRUE))
+  set_hand(hand_spec)
 
   neutral_hand <- hand(seed = hand_spec$seed)
-  invisible(with_hand_seed(neutral_hand$seed, {
+  invisible(with_hand_seed(seed = neutral_hand$seed, expr = {
     if (is.null(fill_pattern)) {
       if (is_visible_col(col) || is_visible_col(border)) {
         do.call(primitive, c(shape_args, list(col = col, border = border), dots))
@@ -558,13 +558,13 @@ draw_rough_polypath <- function(x, y = NULL, id = NULL, rule = c("winding", "eve
   if (is_mypaintr_device()) {
     solid_path <- join_polypath_na(paths0)
     return(draw_mypaintr_rough_shape(
-      graphics::polypath,
-      list(x = solid_path$x, y = solid_path$y, rule = rule),
-      paths0,
-      hand_spec,
-      fill_pattern,
-      col,
-      border,
+      primitive = graphics::polypath,
+      shape_args = list(x = solid_path$x, y = solid_path$y, rule = rule),
+      paths = paths0,
+      hand_spec = hand_spec,
+      fill_pattern = fill_pattern,
+      col = col,
+      border = border,
       rule = rule,
       ...
     ))
@@ -632,13 +632,13 @@ draw_rough_polygons <- function(x, y = NULL, hand = NULL, col = NA, border = gra
 
   if (is_mypaintr_device()) {
     return(draw_mypaintr_rough_shape(
-      graphics::polygon,
-      list(x = xy$x, y = xy$y),
-      list(list(x = xy$x, y = xy$y)),
-      hand_spec,
-      fill_pattern,
-      col,
-      border,
+      primitive = graphics::polygon,
+      shape_args = list(x = xy$x, y = xy$y),
+      paths = list(list(x = xy$x, y = xy$y)),
+      hand_spec = hand_spec,
+      fill_pattern = fill_pattern,
+      col = col,
+      border = border,
       ...
     ))
   }

--- a/R/draw-rough.R
+++ b/R/draw-rough.R
@@ -499,6 +499,39 @@ warn_missing_fill_for_pattern <- function(fill_pattern, col) {
   }
 }
 
+draw_mypaintr_rough_shape <- function(primitive, shape_args, paths, hand_spec,
+                                      fill_pattern, col, border, rule = NULL, ...) {
+  dots <- list(...)
+
+  state <- current_device_style()
+  on.exit(apply_device_style_state(state), add = TRUE)
+  invisible(.Call(mypaintr_device_set_hand, hand_spec, hand_spec, TRUE, TRUE))
+
+  neutral_hand <- hand(seed = hand_spec$seed)
+  invisible(with_hand_seed(neutral_hand$seed, {
+    if (is.null(fill_pattern)) {
+      if (is_visible_col(col) || is_visible_col(border)) {
+        do.call(primitive, c(shape_args, list(col = col, border = border), dots))
+      }
+    } else {
+      if (is_visible_col(col)) {
+        fill_args <- c(
+          list(paths = paths, hand_spec = neutral_hand, col = col, fill_pattern = fill_pattern),
+          dots
+        )
+        if (!is.null(rule)) {
+          fill_args$rule <- rule
+        }
+        do.call(draw_rough_fill_pattern, fill_args)
+      }
+      if (is_visible_col(border)) {
+        do.call(primitive, c(shape_args, list(col = NA, border = border), dots))
+      }
+    }
+    NULL
+  }))
+}
+
 #' @rdname rough_polypath
 #' @inheritParams mypaintr-rough-fill
 #' @param ... Graphics parameters passed to [graphics::lines()].
@@ -523,47 +556,18 @@ draw_rough_polypath <- function(x, y = NULL, id = NULL, rule = c("winding", "eve
   warn_missing_fill_for_pattern(fill_pattern, col)
 
   if (is_mypaintr_device()) {
-    state <- current_device_style()
-    on.exit(apply_device_style_state(state), add = TRUE)
-    invisible(.Call(mypaintr_device_set_hand, hand_spec, hand_spec, TRUE, TRUE))
-
-    neutral_hand <- hand(seed = hand_spec$seed)
-    return(invisible(with_hand_seed(neutral_hand$seed, {
-      if (is.null(fill_pattern)) {
-        if (is_visible_col(col) || is_visible_col(border)) {
-          solid_path <- join_polypath_na(paths0)
-          do.call(
-            graphics::polypath,
-            c(
-              list(x = solid_path$x, y = solid_path$y, rule = rule, col = col, border = border),
-              list(...)
-            )
-          )
-        }
-      } else {
-        if (is_visible_col(col)) {
-          draw_rough_fill_pattern(
-            paths0,
-            neutral_hand,
-            col = col,
-            fill_pattern = fill_pattern,
-            rule = rule,
-            ...
-          )
-        }
-        if (is_visible_col(border)) {
-          solid_path <- join_polypath_na(paths0)
-          do.call(
-            graphics::polypath,
-            c(
-              list(x = solid_path$x, y = solid_path$y, rule = rule, col = NA, border = border),
-              list(...)
-            )
-          )
-        }
-      }
-      NULL
-    })))
+    solid_path <- join_polypath_na(paths0)
+    return(draw_mypaintr_rough_shape(
+      graphics::polypath,
+      list(x = solid_path$x, y = solid_path$y, rule = rule),
+      paths0,
+      hand_spec,
+      fill_pattern,
+      col,
+      border,
+      rule = rule,
+      ...
+    ))
   }
 
   invisible(with_hand_seed(hand_spec$seed, {
@@ -627,44 +631,16 @@ draw_rough_polygons <- function(x, y = NULL, hand = NULL, col = NA, border = gra
   warn_missing_fill_for_pattern(fill_pattern, col)
 
   if (is_mypaintr_device()) {
-    state <- current_device_style()
-    on.exit(apply_device_style_state(state), add = TRUE)
-    invisible(.Call(mypaintr_device_set_hand, hand_spec, hand_spec, TRUE, TRUE))
-
-    neutral_hand <- hand(seed = hand_spec$seed)
-    return(invisible(with_hand_seed(neutral_hand$seed, {
-      if (is.null(fill_pattern)) {
-        if (is_visible_col(col) || is_visible_col(border)) {
-          do.call(
-            graphics::polygon,
-            c(
-              list(x = xy$x, y = xy$y, col = col, border = border),
-              list(...)
-            )
-          )
-        }
-      } else {
-        if (is_visible_col(col)) {
-          draw_rough_fill_pattern(
-            list(list(x = xy$x, y = xy$y)),
-            neutral_hand,
-            col = col,
-            fill_pattern = fill_pattern,
-            ...
-          )
-        }
-        if (is_visible_col(border)) {
-          do.call(
-            graphics::polygon,
-            c(
-              list(x = xy$x, y = xy$y, col = NA, border = border),
-              list(...)
-            )
-          )
-        }
-      }
-      NULL
-    })))
+    return(draw_mypaintr_rough_shape(
+      graphics::polygon,
+      list(x = xy$x, y = xy$y),
+      list(list(x = xy$x, y = xy$y)),
+      hand_spec,
+      fill_pattern,
+      col,
+      border,
+      ...
+    ))
   }
 
   invisible(with_hand_seed(hand_spec$seed, {

--- a/R/draw-rough.R
+++ b/R/draw-rough.R
@@ -522,6 +522,50 @@ draw_rough_polypath <- function(x, y = NULL, id = NULL, rule = c("winding", "eve
   fill_pattern <- as_fill_pattern(fill_pattern, hand_spec = hand_spec)
   warn_missing_fill_for_pattern(fill_pattern, col)
 
+  if (is_mypaintr_device()) {
+    state <- current_device_style()
+    on.exit(apply_device_style_state(state), add = TRUE)
+    invisible(.Call(mypaintr_device_set_hand, hand_spec, hand_spec, TRUE, TRUE))
+
+    neutral_hand <- hand(seed = hand_spec$seed)
+    return(invisible(with_hand_seed(neutral_hand$seed, {
+      if (is.null(fill_pattern)) {
+        if (is_visible_col(col) || is_visible_col(border)) {
+          solid_path <- join_polypath_na(paths0)
+          do.call(
+            graphics::polypath,
+            c(
+              list(x = solid_path$x, y = solid_path$y, rule = rule, col = col, border = border),
+              list(...)
+            )
+          )
+        }
+      } else {
+        if (is_visible_col(col)) {
+          draw_rough_fill_pattern(
+            paths0,
+            neutral_hand,
+            col = col,
+            fill_pattern = fill_pattern,
+            rule = rule,
+            ...
+          )
+        }
+        if (is_visible_col(border)) {
+          solid_path <- join_polypath_na(paths0)
+          do.call(
+            graphics::polypath,
+            c(
+              list(x = solid_path$x, y = solid_path$y, rule = rule, col = NA, border = border),
+              list(...)
+            )
+          )
+        }
+      }
+      NULL
+    })))
+  }
+
   invisible(with_hand_seed(hand_spec$seed, {
     geom <- rough_polypath_data(paths0, hand_spec, rule)
     paths <- split_polypath(geom$x, geom$y, geom$id)
@@ -581,6 +625,47 @@ draw_rough_polygons <- function(x, y = NULL, hand = NULL, col = NA, border = gra
   xy <- grDevices::xy.coords(x, y)
   fill_pattern <- as_fill_pattern(fill_pattern, hand_spec = hand_spec)
   warn_missing_fill_for_pattern(fill_pattern, col)
+
+  if (is_mypaintr_device()) {
+    state <- current_device_style()
+    on.exit(apply_device_style_state(state), add = TRUE)
+    invisible(.Call(mypaintr_device_set_hand, hand_spec, hand_spec, TRUE, TRUE))
+
+    neutral_hand <- hand(seed = hand_spec$seed)
+    return(invisible(with_hand_seed(neutral_hand$seed, {
+      if (is.null(fill_pattern)) {
+        if (is_visible_col(col) || is_visible_col(border)) {
+          do.call(
+            graphics::polygon,
+            c(
+              list(x = xy$x, y = xy$y, col = col, border = border),
+              list(...)
+            )
+          )
+        }
+      } else {
+        if (is_visible_col(col)) {
+          draw_rough_fill_pattern(
+            list(list(x = xy$x, y = xy$y)),
+            neutral_hand,
+            col = col,
+            fill_pattern = fill_pattern,
+            ...
+          )
+        }
+        if (is_visible_col(border)) {
+          do.call(
+            graphics::polygon,
+            c(
+              list(x = xy$x, y = xy$y, col = NA, border = border),
+              list(...)
+            )
+          )
+        }
+      }
+      NULL
+    })))
+  }
 
   invisible(with_hand_seed(hand_spec$seed, {
     rough_outline <- roughen_vertex_path(xy$x, xy$y, hand_spec, closed = TRUE)

--- a/src/device.c
+++ b/src/device.c
@@ -140,6 +140,18 @@ static inline int colors_close(int lhs, int rhs, int tol) {
          abs(R_ALPHA(lhs) - R_ALPHA(rhs)) <= tol;
 }
 
+static inline double device_lwd_scale(const MypaintrDevice *dev) {
+  return dev->res / 96.0;
+}
+
+static inline double device_lwd(const MypaintrDevice *dev, double lwd) {
+  return fmax(lwd * device_lwd_scale(dev), 1e-3);
+}
+
+static inline double device_length(const MypaintrDevice *dev, double x) {
+  return x * device_lwd_scale(dev);
+}
+
 static uint64_t mix64(uint64_t x) {
   x += 0x9e3779b97f4a7c15ULL;
   x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ULL;
@@ -1208,10 +1220,10 @@ static void save_page(MypaintrDevice *dev) {
   }
 }
 
-static void brush_apply_gc(MypaintrBrush *brush, int col, double lwd) {
+static void brush_apply_gc(const MypaintrDevice *dev, MypaintrBrush *brush, int col, double lwd) {
   double h, s, v;
   double alpha = R_ALPHA(col) / 255.0;
-  double width_factor = fmax(lwd, 1e-3);
+  double width_factor = device_lwd(dev, lwd);
 
   rgb_to_hsv(
     R_RED(col) / 255.0,
@@ -1595,7 +1607,7 @@ static void render_polyline_solid(MypaintrDevice *dev, MypaintrBrush *brush, con
     pressure_hand = &dev->fill_hand;
   }
 
-  brush_apply_gc(brush, col, lwd);
+  brush_apply_gc(dev, brush, col, lwd);
   start_dx = x[1] - x[0];
   start_dy = y[1] - y[0];
   start_len = sqrt(start_dx * start_dx + start_dy * start_dy);
@@ -1695,6 +1707,7 @@ static void cairo_set_lty(cairo_t *cr, int lty, double lwd) {
 static void solid_stroke_polyline(MypaintrDevice *dev, const double *x, const double *y, int n, int col, double lwd, int lty, int closed, const MypaintrHand *hand) {
   int i;
   double total_len = 0.0;
+  double scaled_lwd = device_lwd(dev, lwd);
   int emulate_pressure = 0;
 
   if (n < 2 || R_ALPHA(col) == 0 || lty == LTY_BLANK) {
@@ -1746,7 +1759,7 @@ static void solid_stroke_polyline(MypaintrDevice *dev, const double *x, const do
         double y1 = sy + dy * u1;
         double mid = cumulative + seg_len * (u0 + u1) * 0.5;
         double t = mid / total_len;
-        double width = fmax(1e-3, lwd * stroke_pressure_at(hand, t, polyline_turn_factor(x, y, n, i - 1)));
+        double width = fmax(1e-3, scaled_lwd * stroke_pressure_at(hand, t, polyline_turn_factor(x, y, n, i - 1)));
 
         cairo_new_path(dev->cr);
         cairo_move_to(dev->cr, x0, flip_y(dev, y0));
@@ -1772,17 +1785,17 @@ static void solid_stroke_polyline(MypaintrDevice *dev, const double *x, const do
     cairo_close_path(dev->cr);
   }
   set_cairo_source(dev->cr, col);
-  cairo_set_line_width(dev->cr, fmax(lwd, 1e-3));
+  cairo_set_line_width(dev->cr, scaled_lwd);
   cairo_set_line_cap(dev->cr, CAIRO_LINE_CAP_ROUND);
   cairo_set_line_join(dev->cr, CAIRO_LINE_JOIN_ROUND);
-  cairo_set_lty(dev->cr, lty, lwd);
+  cairo_set_lty(dev->cr, lty, scaled_lwd);
   cairo_stroke(dev->cr);
   cairo_restore(dev->cr);
 }
 
 static void render_polyline(MypaintrDevice *dev, MypaintrBrush *brush, const double *x, const double *y, int n, int col, double lwd, int lty) {
   double pattern[8];
-  int pattern_n = decode_lty(lty, lwd, pattern, 8);
+  int pattern_n = decode_lty(lty, device_lwd(dev, lwd), pattern, 8);
   int pattern_i = 0;
   double remaining;
   int draw_on = 1;
@@ -1896,7 +1909,7 @@ static int cmp_intersection(const void *lhs, const void *rhs) {
 }
 
 static void hatch_fill_path(MypaintrDevice *dev, MypaintrBrush *brush, int npoly, const int *nper, const double *x, const double *y, int fill, int rule) {
-  double radius = exp(brush->base_radius_log);
+  double radius = device_length(dev, exp(brush->base_radius_log));
   double spacing = fmax(2.0, radius * 1.5);
   double min_y = y[0];
   double max_y = y[0];
@@ -1977,7 +1990,7 @@ static void hatch_fill_polygon(MypaintrDevice *dev, MypaintrBrush *brush, int n,
 }
 
 static void hatch_fill_rect(MypaintrDevice *dev, MypaintrBrush *brush, double x0, double y0, double x1, double y1, int fill) {
-  double radius = exp(brush->base_radius_log);
+  double radius = device_length(dev, exp(brush->base_radius_log));
   double spacing = fmax(2.0, radius * 1.5);
   double left = fmin(x0, x1);
   double right = fmax(x0, x1);
@@ -1992,7 +2005,7 @@ static void hatch_fill_rect(MypaintrDevice *dev, MypaintrBrush *brush, double x0
 }
 
 static void hatch_fill_circle(MypaintrDevice *dev, MypaintrBrush *brush, double x, double y, double r, int fill) {
-  double radius = exp(brush->base_radius_log);
+  double radius = device_length(dev, exp(brush->base_radius_log));
   double spacing = fmax(2.0, radius * 1.5);
 
   for (double yy = y - r; yy <= y + r; yy += spacing) {

--- a/vignettes/hand-demo.Rmd
+++ b/vignettes/hand-demo.Rmd
@@ -10,7 +10,7 @@ vignette: >
 
 ```{r, include = FALSE}
 library(mypaintr)
-knitr::knit_hooks$set(mypaint = knitr_mypaint_hook())
+knitr::knit_hooks$set(mypaint = knitr_mypaint_hook(res = 288))
 
 knitr::opts_chunk$set(
   collapse = TRUE,


### PR DESCRIPTION
## Summary

- On `mypaint_device()`, `draw_rough_polygons()` and `draw_rough_polypath()` now temporarily apply the supplied `hand` to the device and run the existing rough drawing path with a neutral R-side hand, avoiding double roughening.
- Scale device stroke widths, dash spacing, brush radius from `lwd`, and brush-fill spacing by `res / 96` so higher-resolution PNGs gain real stroke detail instead of only a larger canvas.
- Render the hand demo at `res = 288` through `knitr_mypaint_hook()`.

## Root Cause

The rough helpers were roughening geometry in R even when the mypaint device could apply the hand itself. Separately, the device treated `lwd` and brush radii as raw pixels, so increasing `res` enlarged the bitmap without increasing stroke detail.

## Validation

- Rendered and measured equivalent line thickness at `res = 144` and `res = 288`; `mypaint_device()` now matches base `png()` for the measured `lwd = 6` case.
- Rendered `vignettes/hand-demo.Rmd` with the rebuilt source. The only warning was the existing vignette title capitalization warning.