### PR TITLE
[codex] Simplify internal brush and device style code

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,6 +2,7 @@
 ^\.Rproj\.user$
 ^\.DS_Store$
 ^\.github$
+^\.git$
 ^Rplots\.pdf$
 ^docs$
 ^build$

--- a/R/brushes.R
+++ b/R/brushes.R
@@ -33,13 +33,9 @@ normalize_brush_source <- function(brush) {
     stop("unknown brush file: ", brush, call. = FALSE)
   }
   new_mypaintr_brush(
-    json = read_mypaint_brush(brush_file),
+    json = paste(readLines(brush_file, warn = FALSE, encoding = "UTF-8"), collapse = "\n"),
     source = normalizePath(brush_file, winslash = "/", mustWork = TRUE)
   )
-}
-
-is_json_brush_string <- function(brush) {
-  is.character(brush) && length(brush) == 1L && startsWith(trimws(brush), "{")
 }
 
 default_mypaint_brush_dirs <- function() {
@@ -138,11 +134,6 @@ normalize_settings <- function(settings) {
   settings
 }
 
-read_mypaint_brush <- function(path) {
-  paste(readLines(path, warn = FALSE, encoding = "UTF-8"), collapse = "\n")
-}
-
-
 json_brush_base_value <- function(json, setting) {
   pattern <- sprintf(
     '"%s"[[:space:]]*:[[:space:]]*\\{[^}]*"base_value"[[:space:]]*:[[:space:]]*([-+0-9.eE]+)',
@@ -154,25 +145,6 @@ json_brush_base_value <- function(json, setting) {
     return(NA_real_)
   }
   suppressWarnings(as.numeric(captures[[2L]]))
-}
-
-normalize_adjustments <- function(brush, normalize = "none") {
-  normalize <- normalize_mode(normalize)
-  settings <- numeric()
-  if (normalize %in% c("all", "tracking")) {
-    settings[c("slow_tracking", "slow_tracking_per_dab")] <- 0
-  }
-  if (normalize %in% c("all", "size")) {
-    current_radius <- if ("radius_logarithmic" %in% names(brush$settings %||% numeric())) {
-      as.numeric(brush$settings[["radius_logarithmic"]])
-    } else {
-      json_brush_base_value(brush$json %||% "", "radius_logarithmic")
-    }
-    if (is.finite(current_radius) && current_radius > log(3)) {
-      settings["radius_logarithmic"] <- log(3)
-    }
-  }
-  settings
 }
 
 #' Tweak a brush specification
@@ -343,8 +315,19 @@ tweak_brush <- function(brush,
   brush <- normalize_brush_source(brush)
   normalize <- normalize_mode(normalize)
   settings <- brush$settings %||% numeric()
-  normalized <- normalize_adjustments(brush, normalize)
-  settings[names(normalized)] <- normalized
+  if (normalize %in% c("all", "tracking")) {
+    settings[c("slow_tracking", "slow_tracking_per_dab")] <- 0
+  }
+  if (normalize %in% c("all", "size")) {
+    current_radius <- if ("radius_logarithmic" %in% names(settings)) {
+      as.numeric(settings[["radius_logarithmic"]])
+    } else {
+      json_brush_base_value(brush$json %||% "", "radius_logarithmic")
+    }
+    if (is.finite(current_radius) && current_radius > log(3)) {
+      settings["radius_logarithmic"] <- log(3)
+    }
+  }
   overrides <- as.list(match.call())[-1]
   overrides$normalize <- NULL
   overrides$brush <- NULL
@@ -364,7 +347,10 @@ normalize_brush_spec <- function(brush) {
   if (is.null(brush)) {
     return(NULL)
   }
-  if (!inherits(brush, "mypaintr_brush") && !is_json_brush_string(brush)) {
+  if (
+    !inherits(brush, "mypaintr_brush") &&
+      !(is.character(brush) && length(brush) == 1L && startsWith(trimws(brush), "{"))
+  ) {
     brush <- tweak_brush(brush, normalize = "all")
   }
   brush <- normalize_brush_source(brush)
@@ -432,7 +418,7 @@ set_brush <- function(brush = NULL, type = c("both", "stroke", "fill"), auto_sol
   }
 
   invisible(.Call(
-    mypaintr_device_set_brush,
+    mypaintr_device_set_style,
     stroke_spec,
     fill_spec,
     if (is.null(stroke_style)) NULL else as.integer(stroke_style),

--- a/R/device-style.R
+++ b/R/device-style.R
@@ -87,14 +87,6 @@ make_style_override <- function(update_stroke = FALSE,
   )
 }
 
-normalize_render_style <- function(style) {
-  if (is.null(style)) {
-    return(NULL)
-  }
-  style <- match.arg(style, c("solid", "brush"))
-  match(style, c("solid", "brush")) - 1L
-}
-
 #' Open a libmypaint-backed graphics device
 #'
 #' @param filename Output PNG filename. If it contains `\%d`, pages are
@@ -204,48 +196,5 @@ mypaint_device <- function(filename = NULL,
     if (auto_solid_bg_missing) TRUE else isTRUE(auto_solid_bg),
     normalize_hand_spec(stroke_hand),
     normalize_hand_spec(fill_hand)
-  ))
-}
-
-#' Update the active mypaintr device style
-#'
-#' @param brush Stroke brush specification created with [tweak_brush()], an
-#'   installed brush name, `.myb` file path, JSON brush string, or `NULL` for
-#'   solid strokes.
-#' @param stroke_style Either `"brush"` or `"solid"`.
-#' @param fill_style Either `"solid"` or `"brush"`.
-#' @param fill_brush Fill brush specification created with [tweak_brush()], an
-#'   installed brush name, `.myb` file path, JSON brush string, or `NULL` for
-#'   solid fills.
-#' @param auto_solid_bg Whether large fills matching the device background should
-#'   be drawn normally.
-#' @return `NULL`, invisibly.
-#' @keywords internal
-#' @noRd
-mypaint_style <- function(brush = NULL,
-                          stroke_style = NULL,
-                          fill_style = NULL,
-                          fill_brush = NULL,
-                          auto_solid_bg = NULL) {
-  supplied_args <- names(match.call(expand.dots = FALSE))
-  brush_missing <- !("brush" %in% supplied_args)
-  fill_brush_missing <- !("fill_brush" %in% supplied_args)
-  stroke_spec <- if (brush_missing) NULL else if (is.null(brush)) NULL else normalize_brush_spec(brush)
-  fill_spec <- if (fill_brush_missing) NULL else if (is.null(fill_brush)) NULL else normalize_brush_spec(fill_brush)
-
-  stroke_style <- normalize_render_style(stroke_style)
-  fill_style <- normalize_render_style(fill_style)
-
-  if (!is_mypaintr_device()) {
-    return(invisible(NULL))
-  }
-
-  invisible(.Call(
-    mypaintr_device_set_style,
-    stroke_spec,
-    fill_spec,
-    stroke_style,
-    fill_style,
-    if (is.null(auto_solid_bg)) NULL else isTRUE(auto_solid_bg)
   ))
 }

--- a/R/hatching.R
+++ b/R/hatching.R
@@ -251,17 +251,6 @@ point_in_paths <- function(paths, x, y, rule = c("winding", "evenodd")) {
   }, logical(1))
 }
 
-path_bbox <- function(paths) {
-  xs <- unlist(lapply(paths, `[[`, "x"), use.names = FALSE)
-  ys <- unlist(lapply(paths, `[[`, "y"), use.names = FALSE)
-  list(
-    xmin = min(xs),
-    xmax = max(xs),
-    ymin = min(ys),
-    ymax = max(ys)
-  )
-}
-
 rotate_xy <- function(x, y, angle_deg) {
   theta <- angle_deg * pi / 180
   cth <- cos(theta)

--- a/src/device.c
+++ b/src/device.c
@@ -121,13 +121,6 @@ static inline unsigned char unit_to_byte(double x) {
   return (unsigned char) (y + 0.5);
 }
 
-static inline int colors_close(int lhs, int rhs, int tol) {
-  return abs(R_RED(lhs) - R_RED(rhs)) <= tol &&
-         abs(R_GREEN(lhs) - R_GREEN(rhs)) <= tol &&
-         abs(R_BLUE(lhs) - R_BLUE(rhs)) <= tol &&
-         abs(R_ALPHA(lhs) - R_ALPHA(rhs)) <= tol;
-}
-
 static inline double device_lwd_scale(const MypaintrDevice *dev) {
   return dev->res / 96.0;
 }
@@ -618,7 +611,7 @@ static double flip_y(const MypaintrDevice *dev, double y) {
   return (double) dev->height - y;
 }
 
-static void set_font_face_for_context(cairo_t *cr, double res, const pGEcontext gc) {
+static void set_font_face(const MypaintrDevice *dev, const pGEcontext gc) {
   cairo_font_slant_t slant = CAIRO_FONT_SLANT_NORMAL;
   cairo_font_weight_t weight = CAIRO_FONT_WEIGHT_NORMAL;
 
@@ -630,16 +623,12 @@ static void set_font_face_for_context(cairo_t *cr, double res, const pGEcontext 
   }
 
   cairo_select_font_face(
-    cr,
+    dev->cr,
     gc->fontfamily[0] ? gc->fontfamily : "sans",
     slant,
     weight
   );
-  cairo_set_font_size(cr, gc->cex * gc->ps * res / 72.0);
-}
-
-static void set_font_face(const MypaintrDevice *dev, const pGEcontext gc) {
-  set_font_face_for_context(dev->cr, dev->res, gc);
+  cairo_set_font_size(dev->cr, gc->cex * gc->ps * dev->res / 72.0);
 }
 
 static void apply_cairo_clip(MypaintrDevice *dev) {
@@ -1182,14 +1171,6 @@ static void render_polyline_mode(MypaintrDevice *dev, MypaintrBrush *brush, int 
   }
 }
 
-static void render_polyline_mode_hand(MypaintrDevice *dev, MypaintrBrush *brush, int render_style, const double *x, const double *y, int n, int col, double lwd, int lty, int closed, const MypaintrHand *hand) {
-  if (render_style == MYPAINTR_RENDER_BRUSH) {
-    render_polyline(dev, brush, x, y, n, col, lwd, lty, hand);
-  } else {
-    solid_stroke_polyline(dev, x, y, n, col, lwd, lty, closed, hand);
-  }
-}
-
 static void render_polyline_hand(MypaintrDevice *dev, MypaintrBrush *brush, int render_style, const double *x, const double *y, int n, int col, double lwd, int lty, int closed, MypaintrHand *hand) {
   int i;
 
@@ -1203,7 +1184,11 @@ static void render_polyline_hand(MypaintrDevice *dev, MypaintrBrush *brush, int 
     double jittered_lwd;
     roughen_vertex_path(x, y, n, hand, closed, &path);
     jittered_lwd = fmax(0.01, lwd * (1.0 + hand_normal(hand, hand->width_jitter)));
-    render_polyline_mode_hand(dev, brush, render_style, path.x, path.y, path.n, col, jittered_lwd, lty, 0, hand);
+    if (render_style == MYPAINTR_RENDER_BRUSH) {
+      render_polyline(dev, brush, path.x, path.y, path.n, col, jittered_lwd, lty, hand);
+    } else {
+      solid_stroke_polyline(dev, path.x, path.y, path.n, col, jittered_lwd, lty, 0, hand);
+    }
     point_buffer_free(&path);
   }
 }
@@ -1368,36 +1353,30 @@ static void fill_polygon_mode(MypaintrDevice *dev, int n, const double *x, const
   }
 }
 
-static int should_solid_fill_rect(const MypaintrDevice *dev, double x0, double y0, double x1, double y1, int fill) {
-  double area;
-  double device_area;
-
-  if (R_ALPHA(fill) == 0) {
-    return 1;
-  }
-  if (!dev->auto_solid_bg) {
-    return 0;
-  }
-
-  area = fabs(x1 - x0) * fabs(y1 - y0);
-  device_area = (double) dev->width * (double) dev->height;
-
-  if (area < 0.10 * device_area) {
-    return 0;
-  }
-
-  return colors_close(fill, dev->bg, 12);
-}
-
 static void fill_rect(MypaintrDevice *dev, double x0, double y0, double x1, double y1, int fill) {
   double xs[4] = {x0, x1, x1, x0};
   double ys[4] = {y0, y0, y1, y1};
+  double area = fabs(x1 - x0) * fabs(y1 - y0);
+  double device_area = (double) dev->width * (double) dev->height;
+  int should_brush_fill = dev->fill_style == MYPAINTR_FILL_BRUSH;
 
   if (R_ALPHA(fill) == 0) {
     return;
   }
 
-  if (dev->fill_style == MYPAINTR_FILL_BRUSH && !should_solid_fill_rect(dev, x0, y0, x1, y1, fill)) {
+  if (
+    should_brush_fill &&
+      dev->auto_solid_bg &&
+      area >= 0.10 * device_area &&
+      abs(R_RED(fill) - R_RED(dev->bg)) <= 12 &&
+      abs(R_GREEN(fill) - R_GREEN(dev->bg)) <= 12 &&
+      abs(R_BLUE(fill) - R_BLUE(dev->bg)) <= 12 &&
+      abs(R_ALPHA(fill) - R_ALPHA(dev->bg)) <= 12
+  ) {
+    should_brush_fill = 0;
+  }
+
+  if (should_brush_fill) {
     if (dev->fill_hand.enabled) {
       fill_polygon_mode(dev, 4, xs, ys, fill, R_GE_nonZeroWindingRule, &dev->fill_hand);
     } else {
@@ -2131,13 +2110,6 @@ SEXP mypaintr_device_open(SEXP filename, SEXP width, SEXP height, SEXP res, SEXP
   int pixel_height;
   int bg;
 
-  if (TYPEOF(filename) != STRSXP || XLENGTH(filename) != 1) {
-    error("filename must be a character scalar");
-  }
-  if (TYPEOF(bg_rgba) != INTSXP || XLENGTH(bg_rgba) != 4) {
-    error("background colour must be an RGBA integer vector");
-  }
-
   pixel_width = (int) llround(asReal(width) * asReal(res));
   pixel_height = (int) llround(asReal(height) * asReal(res));
   bg = R_RGBA(INTEGER(bg_rgba)[0], INTEGER(bg_rgba)[1], INTEGER(bg_rgba)[2], INTEGER(bg_rgba)[3]);
@@ -2197,10 +2169,6 @@ SEXP mypaintr_device_set_style(SEXP stroke_spec, SEXP fill_spec, SEXP stroke_sty
   }
 
   return R_NilValue;
-}
-
-SEXP mypaintr_device_set_brush(SEXP stroke_spec, SEXP fill_spec, SEXP stroke_style, SEXP fill_style, SEXP auto_solid_bg) {
-  return mypaintr_device_set_style(stroke_spec, fill_spec, stroke_style, fill_style, auto_solid_bg);
 }
 
 SEXP mypaintr_device_set_hand(SEXP stroke_hand, SEXP fill_hand, SEXP update_stroke, SEXP update_fill) {

--- a/src/init.c
+++ b/src/init.c
@@ -4,7 +4,6 @@
 
 SEXP mypaintr_device_open(SEXP filename, SEXP width, SEXP height, SEXP res, SEXP pointsize, SEXP bg_rgba, SEXP stroke_spec, SEXP fill_spec, SEXP stroke_style, SEXP fill_style, SEXP auto_solid_bg, SEXP stroke_hand, SEXP fill_hand);
 SEXP mypaintr_device_set_style(SEXP stroke_spec, SEXP fill_spec, SEXP stroke_style, SEXP fill_style, SEXP auto_solid_bg);
-SEXP mypaintr_device_set_brush(SEXP stroke_spec, SEXP fill_spec, SEXP stroke_style, SEXP fill_style, SEXP auto_solid_bg);
 SEXP mypaintr_device_set_hand(SEXP stroke_hand, SEXP fill_hand, SEXP update_stroke, SEXP update_fill);
 SEXP mypaintr_device_get_style(void);
 SEXP mypaintr_brush_settings_info(void);
@@ -13,7 +12,6 @@ SEXP mypaintr_brush_inputs_info(void);
 static const R_CallMethodDef call_methods[] = {
   {"mypaintr_device_open", (DL_FUNC) &mypaintr_device_open, 13},
   {"mypaintr_device_set_style", (DL_FUNC) &mypaintr_device_set_style, 5},
-  {"mypaintr_device_set_brush", (DL_FUNC) &mypaintr_device_set_brush, 5},
   {"mypaintr_device_set_hand", (DL_FUNC) &mypaintr_device_set_hand, 4},
   {"mypaintr_device_get_style", (DL_FUNC) &mypaintr_device_get_style, 0},
   {"mypaintr_brush_settings_info", (DL_FUNC) &mypaintr_brush_settings_info, 0},


### PR DESCRIPTION
## Summary

- Remove unused internal R helpers and a dead `mypaint_style()` path.
- Route `set_brush()` through the existing native style setter instead of a duplicate C wrapper.
- Inline small one-use C helpers and remove duplicate native validation that R already performs.
- Ignore the `.git` file created by git worktrees so source builds from `/tmp` worktrees do not report a false hidden-file NOTE.

## Validation

- `R CMD INSTALL --preclean .`
- Smoke test opening `mypaint_device()`, using `set_brush()`, `set_hand()`, and drawing a hatched rough rectangle to a non-empty PNG.
- `R CMD check --no-manual --ignore-vignettes mypaintr_0.0.1.9000.tar.gz`